### PR TITLE
noise plugin: missing parameter sourceNode

### DIFF
--- a/src/Plugin/Noise.js
+++ b/src/Plugin/Noise.js
@@ -1,4 +1,4 @@
-ScarletsMediaEffect.noise = function(){
+ScarletsMediaEffect.noise = function(sourceNode){
 	var context = ScarletsMedia.audioContext;
 	var output = context.createGain();
 	var input = sourceNode === undefined ? context.createGain() : null;


### PR DESCRIPTION
Hi Stefans, it seems that the parameter sourceNode was missing from the noise plugin

EJ